### PR TITLE
Librosa 0.7.0 breaks Honk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 chainmap
 cherrypy>=11.0.0,<=11.99
-librosa>=0.6.2
+librosa>=0.6.2,<=0.6.3
 Flask>=0.12.1
 numpy>=1.12
 Pillow>=4.0.0,<=4.99


### PR DESCRIPTION
utils/manage_audio.py uses librosa.filters.dct, however dct was apparently removed from 0.6.3 to 0.7.0.